### PR TITLE
Update application.conf

### DIFF
--- a/web/conf/application.conf
+++ b/web/conf/application.conf
@@ -45,9 +45,10 @@ date.format=yyyy-MM-dd
 # By default, session will be written to the transient PLAY_SESSION cookie.
 # The cookies are not secured by default, only set it to true
 # if you're serving your pages through https.
-# application.session.cookie=PLAY
-# application.session.maxAge=1h
-# application.session.secure=false
+application.session.cookie=PLAY
+application.session.maxAge=1h
+application.session.secure=false
+application.session.httponly=false
 
 # Session/Cookie sharing between subdomain
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Obligo a que la cookie sólo sea válida para una conexión encriptada (https), con una validez máxima de 1 hora y sólo accesible para los protocolos http o https

application.session.cookie=PLAY
application.session.maxAge=1h
application.session.secure=true
application.session.httponly=true